### PR TITLE
Display ugly warning until we "officially" release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Here be dragons! Alpha-quality software! It may eat your dog!
+
 # Pusher CLI [(pusher.com)](https://pusher.com)
 
 This is a tool that allows developers access to their Pusher accounts via a command line interface. 


### PR DESCRIPTION
Having the repo public is great but it should be made clear that it's not recommended for use quite yet.