### PR TITLE
Add channel list and channel info commands

### DIFF
--- a/commands/channels/channel_info.go
+++ b/commands/channels/channel_info.go
@@ -1,0 +1,88 @@
+package channels
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/pusher/cli/api"
+	"github.com/pusher/cli/commands"
+	"github.com/pusher/pusher-http-go"
+	"github.com/spf13/cobra"
+)
+
+var ChannelInfo = &cobra.Command{
+	Use:   "channel-info",
+	Short: "Get info about a specific channel",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		if commands.AppID == "" {
+			fmt.Fprintf(os.Stderr, "Please supply --app-id\n")
+			os.Exit(1)
+			return
+		}
+
+		if commands.ChannelName == "" {
+			fmt.Fprintf(os.Stderr, "Please supply --channel\n")
+			os.Exit(1)
+			return
+		}
+
+		app, err := api.GetApp(commands.AppID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not get app the app: %s\n", err.Error())
+			os.Exit(1)
+			return
+		}
+
+		token, err := api.GetToken(commands.AppID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not get app token: %s\n", err.Error())
+			os.Exit(1)
+			return
+		}
+
+		client := pusher.Client{
+			AppId:   commands.AppID,
+			Key:     token.Key,
+			Secret:  token.Secret,
+			Cluster: app.Cluster,
+		}
+
+		infoValues := []string{}
+
+		if commands.FetchUserCount {
+			infoValues = append(infoValues, "user_count")
+		}
+		if commands.FetchSubscriptionCount {
+			infoValues = append(infoValues, "subscription_count")
+		}
+
+		additionalQueries := map[string]string{}
+
+		if len(infoValues) > 0 {
+			infoString := infoValues[0]
+			for i := 1; i < len(infoValues); i++ {
+				infoString += "," + infoValues[i]
+			}
+			additionalQueries["info"] = infoString
+		}
+
+		channel, err := client.Channel(commands.ChannelName, additionalQueries)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not get channel: %s\n", err.Error())
+			return
+		}
+
+		channelJSONBytes, _ := json.MarshalIndent(channel, "", "	")
+		fmt.Println(string(channelJSONBytes))
+	},
+}
+
+func init() {
+	ChannelInfo.PersistentFlags().StringVar(&commands.AppID, "app-id", "", "Channels App ID")
+	ChannelInfo.PersistentFlags().StringVar(&commands.ChannelName, "channel", "", "Channel name")
+	ChannelInfo.PersistentFlags().BoolVar(&commands.FetchUserCount, "fetch-user-count", false, "Fetch user count for the presence channel")
+	ChannelInfo.PersistentFlags().BoolVar(&commands.FetchSubscriptionCount, "fetch-subscription-count", false, "Fetch subscription count for the channel")
+}

--- a/commands/channels/list_channels.go
+++ b/commands/channels/list_channels.go
@@ -1,0 +1,67 @@
+package channels
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/pusher/cli/api"
+	"github.com/pusher/cli/commands"
+	"github.com/pusher/pusher-http-go"
+	"github.com/spf13/cobra"
+)
+
+var ListChannels = &cobra.Command{
+	Use:   "list-channels",
+	Short: "List all channels that have at least one subscriber",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		if commands.AppID == "" {
+			fmt.Fprintf(os.Stderr, "Please supply --app-id\n")
+			os.Exit(1)
+			return
+		}
+
+		app, err := api.GetApp(commands.AppID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not get app the app: %s\n", err.Error())
+			os.Exit(1)
+			return
+		}
+
+		token, err := api.GetToken(commands.AppID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not get app token: %s\n", err.Error())
+			os.Exit(1)
+			return
+		}
+
+		client := pusher.Client{
+			AppId:   commands.AppID,
+			Key:     token.Key,
+			Secret:  token.Secret,
+			Cluster: app.Cluster,
+		}
+
+		opts := map[string]string{}
+
+		if commands.FilterByPrefix != "" {
+			opts["filter_by_prefix"] = commands.FilterByPrefix
+		}
+
+		channelsList, err := client.Channels(opts)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not get channel list: %s\n", err.Error())
+			return
+		}
+
+		channelsListJSONBytes, _ := json.MarshalIndent(channelsList.Channels, "", "	")
+		fmt.Println(string(channelsListJSONBytes))
+	},
+}
+
+func init() {
+	ListChannels.PersistentFlags().StringVar(&commands.AppID, "app-id", "", "Channels App ID")
+	ListChannels.PersistentFlags().StringVar(&commands.FilterByPrefix, "filter-by-prefix", "", "A channel name prefix, e.g. 'presence-'")
+}

--- a/commands/shared_flags.go
+++ b/commands/shared_flags.go
@@ -5,3 +5,6 @@ var ChannelName string
 var EventName string
 var Message string
 var OutputAsJSON bool
+var FilterByPrefix string
+var FetchUserCount bool
+var FetchSubscriptionCount bool

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ func main() {
 
 	var Apps = &cobra.Command{Use: "apps",
 		Short: "Manage your Channels Apps"}
-	Apps.AddCommand(channels.Apps, channels.Tokens, channels.Subscribe, channels.Trigger)
+	Apps.AddCommand(channels.Apps, channels.Tokens, channels.Subscribe, channels.Trigger, channels.ListChannels, channels.ChannelInfo)
 
 	var Generate = &cobra.Command{Use: "generate",
 		Short: "Generate a Channels client, server, or Authorisation server"}


### PR DESCRIPTION
Example usage:

```
$ ./pusher channels apps list-channels --app-id 180207
{
	"my-channel": {
		"user_count": 0
	}
}
$ ./pusher channels apps channel-info --app-id 180207 --channel my-channel --fetch-subscription-count
{
	"Name": "my-channel",
	"occupied": true,
	"subscription_count": 2
}
```