### PR TITLE
Fix Goreleaser build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,16 +1,12 @@
-# .goreleaser.yml
-brew: 
-  commit_author: 
-    email: kevin.norman@pusher.com
-    owner: kn100
-  description: "Pusher CLI!"
-  github: 
-    name: homebrew-brew
-    owner: pusher
-  homepage: "https://pusher.com/"
-build: 
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+project_name: pusher
+builds:
+- env:
+  - CGO_ENABLED=0
+build:
   binary: pusher
-  goos: 
+  goos:
     - windows
     - darwin
     - linux
@@ -18,14 +14,35 @@ build:
   goarch:
     - amd64
   ldflags: -s -w -X github.com/pusher/cli/config.version={{.Version}}
-fpm: 
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+nfpm:
+  license: MIT
   description: "Pusher CLI provides access to Pusher platform functionality via a CLI!"
-  formats: 
+  formats:
     - deb
     - rpm
   homepage: "https://pusher.com/"
   maintainer: "Kevin <kevin.norman@pusher.com>"
   vendor: Pusher
-project_name: pusher
-archive:
-  format: zip
+brew:
+  description: "Pusher CLI!"
+  github:
+    name: homebrew-brew
+    owner: pusher
+  homepage: "https://pusher.com/"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,3 +46,4 @@ brew:
     name: homebrew-brew
     owner: pusher
   homepage: "https://pusher.com/"
+  

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -119,7 +119,7 @@
   branch = "master"
   name = "github.com/theherk/viper"
   packages = ["."]
-  revision = "1c64bdc5d63b5e58e48d1d1b4928fc9cf735c399"
+  revision = "e0502e82247dc662b1e65f76039989bda914cfad"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
We've gotten a bit behind with the Goreleaser releases - this deals with deprecations and removes builds nobody was using (bsd).

It also updates a dependency since the commit we pinned to stopped existing.