### PR TITLE
go build with `osusergo` tag, goreleaser update

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,8 @@ build:
   goarch:
     - amd64
   ldflags: -s -w -X github.com/pusher/cli/config.version={{.Version}}
+  tags:
+    - osusergo
 archives:
 - replacements:
     darwin: Darwin
@@ -38,7 +40,7 @@ nfpm:
     - deb
     - rpm
   homepage: "https://pusher.com/"
-  maintainer: "Kevin <kevin.norman@pusher.com>"
+  maintainer: "Pusher <support@pusher.com>"
   vendor: Pusher
 brew:
   description: "Pusher CLI!"
@@ -46,4 +48,4 @@ brew:
     name: homebrew-brew
     owner: pusher
   homepage: "https://pusher.com/"
-  
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,19 +33,19 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
-nfpm:
-  license: MIT
-  description: "Pusher CLI provides access to Pusher platform functionality via a CLI!"
-  formats:
-    - deb
-    - rpm
-  homepage: "https://pusher.com/"
-  maintainer: "Pusher <support@pusher.com>"
-  vendor: Pusher
-brew:
-  description: "Pusher CLI!"
-  github:
-    name: homebrew-brew
-    owner: pusher
-  homepage: "https://pusher.com/"
+nfpms:
+  - license: MIT
+    description: "Pusher CLI provides access to Pusher platform functionality via a CLI!"
+    formats:
+      - deb
+      - rpm
+    homepage: "https://pusher.com/"
+    maintainer: "Pusher <support@pusher.com>"
+    vendor: Pusher
+brews:
+  - description: "Pusher CLI!"
+    tap:
+      name: homebrew-brew
+      owner: pusher
+    homepage: "https://pusher.com/"
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+goreleaser 0.169.0


### PR DESCRIPTION
What does this PR do:
- attempts resolving https://github.com/pusher/cli/issues/44

   https://golang.org/pkg/os/user/ states:
  _"The `os/user` package has two internal implementations of resolving user and group ids to names.
  One is written in pure Go and parses /etc/passwd and /etc/group.
  The other is cgo-based and relies on the standard C library (libc) routines such as getpwuid_r and getgrnam_r.
  When cgo is available, cgo-based (libc-backed) code is used by default.
  This can be overridden by using osusergo build tag, which enforces the pure Go implementation."_
  
  Since we disabled cgo (`CGO_ENABLED=0`) we should specify this build tag to force the native go backend for resolving users.
  
 - bumps the `goreleaser` version to the latest available release (`v0.169.0`)
 - introduces `.tool-versions` to instruct `asdf` on which version of `goreleaser` to use for this project