### PR TITLE
Use 'plaintext' instead of 'param' in functions config

### DIFF
--- a/api/function.go
+++ b/api/function.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 type FunctionService interface {
@@ -107,10 +108,16 @@ func NewUpdateFunctionRequestBody(name string, events *[]string, mode string, bo
 }
 
 func NewCreateFunctionConfigRequest(name string, description string, paramType string, content string) CreateFunctionConfigRequest {
+	convertParamType := func(pt string) string {
+		if strings.ToLower(pt) == "plaintext" {
+			return "param"
+		}
+		return pt
+	}
 	return CreateFunctionConfigRequest{
 		Name:        name,
 		Description: description,
-		ParamType:   paramType,
+		ParamType:   convertParamType(paramType),
 		Content:     content,
 	}
 }

--- a/commands/channels/functions.go
+++ b/commands/channels/functions.go
@@ -19,6 +19,12 @@ import (
 )
 
 func NewConfigListCommand(pusher api.FunctionService) *cobra.Command {
+	convertParamType := func(pt string) string {
+		if strings.ToLower(pt) == "param" {
+			return "plaintext"
+		}
+		return pt
+	}
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List function configs for an Channels app",
@@ -36,7 +42,7 @@ func NewConfigListCommand(pusher api.FunctionService) *cobra.Command {
 				table := newTable(cmd.OutOrStdout())
 				table.SetHeader([]string{"Name", "Desciption", "Type"})
 				for _, config := range configs {
-					table.Append([]string{config.Name, config.Description, config.ParamType})
+					table.Append([]string{config.Name, config.Description, convertParamType(config.ParamType)})
 				}
 				table.Render()
 			}
@@ -78,7 +84,7 @@ func NewConfigCreateCommand(functionService api.FunctionService) (*cobra.Command
 	if err != nil {
 		return nil, err
 	}
-	cmd.PersistentFlags().StringVar(&commands.FunctionConfigParamType, "type", "", "Function config type, valid options: param|secret")
+	cmd.PersistentFlags().StringVar(&commands.FunctionConfigParamType, "type", "", "Function config type, valid options: plaintext|secret")
 	err = cmd.MarkPersistentFlagRequired("type")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The implementation here is a temporary workaround - we should really push this change through pusher-global. But in the interests of getting this out before GA we can tidy that up later.